### PR TITLE
Installer refactor + getPrefix()

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -3,12 +3,14 @@
 'use strict'
 
 const yargs = require('yargs')
-const main = require('../index.js')
+const Installer = require('../index.js')
 
-main(parseArgs()).then((details) => {
-  console.log(`added ${details.count} packages in ${
-    details.time / 1000
+new Installer(parseArgs()).run().then(details => {
+  console.error(`added ${details.pkgCount} packages in ${
+    details.runTime / 1000
   }s.`)
+}, err => {
+  console.error(`Error!\n${err.message}`)
 })
 
 function parseArgs () {

--- a/index.js
+++ b/index.js
@@ -4,34 +4,78 @@ const BB = require('bluebird')
 
 const config = require('./lib/config.js')
 const extract = require('./lib/extract.js')
-const fs = BB.promisifyAll(require('graceful-fs'))
-const path = require('path')
-const rimraf = BB.promisify(require('rimraf'))
+const fs = require('graceful-fs')
+const getPrefix = require('./lib/get-prefix.js')
 const lifecycle = require('npm-lifecycle')
 const lockVerify = require('lock-verify')
+const path = require('path')
+const rimraf = BB.promisify(require('rimraf'))
 
-module.exports = main
+const readFileAsync = BB.promisify(fs.readFile)
 
-function main (opts) {
-  let prefix = path.resolve(opts.prefix || '.')
+class Installer {
+  constructor (opts) {
+    // Config
+    this.opts = opts
 
-  const startTime = Date.now()
-  const nodeModulesPath = path.join(prefix, 'node_modules')
-  let pkgCount = 0
+    // Stats
+    this.startTime = Date.now()
+    this.runTime = null
+    this.pkgCount = 0
 
-  extract.startWorkers()
+    // Misc
+    this.pkg = null
+    this.scriptQ = []
+  }
 
-  return BB.join(
-    readJson(prefix, 'package.json'),
-    readJson(prefix, 'package-lock.json', true),
-    readJson(prefix, 'npm-shrinkwrap.json', true),
-    (pkg, lock, shrink) => {
-      pkg._shrinkwrap = lock || shrink
-      return pkg
-    }
-  ).tap(pkg => {
+  run () {
+    extract.startWorkers()
+
+    return (
+      this.opts.prefix
+      ? BB.resolve(this.opts.prefix)
+      : getPrefix(process.cwd())
+    ).then(prefix => {
+      this.prefix = prefix
+      return BB.join(
+        readJson(prefix, 'package.json'),
+        readJson(prefix, 'package-lock.json', true),
+        readJson(prefix, 'npm-shrinkwrap.json', true),
+        (pkg, lock, shrink) => {
+          pkg._shrinkwrap = lock || shrink
+          this.pkg = pkg
+        }
+      )
+    }).then(() => {
+      return BB.join(
+        this.checkLock(),
+        rimraf(path.join(this.prefix, 'node_modules'))
+      )
+    }).then(() => {
+      return this.runScript('preinstall', this.pkg, this.prefix)
+    }).then(() => {
+      return this.extractDeps(
+        path.join(this.prefix, 'node_modules'),
+        this.pkg._shrinkwrap.dependencies
+      )
+    }).then(() => {
+      return this.runScript('install', this.pkg, this.prefix)
+    }).then(() => {
+      return this.runScript('postinstall', this.pkg, this.prefix)
+    }).then(() => {
+      extract.stopWorkers()
+      this.runTime = Date.now() - this.startTime
+      return this
+    })
+  }
+
+  checkLock () {
+    const pkg = this.pkg
+    const prefix = this.prefix
     if (!pkg._shrinkwrap || !pkg._shrinkwrap.lockfileVersion) {
-      throw new Error(`cipm can only install packages with an existing package-lock.json or npm-shrinkwrap.json with lockfileVersion >= 1. Run an install with npm@5 or later to generate it, then try again.`)
+      return BB.reject(
+        new Error(`cipm can only install packages with an existing package-lock.json or npm-shrinkwrap.json with lockfileVersion >= 1. Run an install with npm@5 or later to generate it, then try again.`)
+      )
     }
     return lockVerify(prefix).then(result => {
       if (result.status) {
@@ -46,47 +90,18 @@ function main (opts) {
         )
       }
     })
-  }).tap(pkg => {
-    return rimraf(nodeModulesPath)
-  }).tap(pkg => {
-    return runScript('preinstall', pkg, prefix)
-  }).tap(pkg => {
-    return extractDeps(
-      nodeModulesPath,
-      pkg._shrinkwrap.dependencies
-    )
-  }).tap(pkg => {
-    return runScript('install', pkg, prefix)
-  }).tap(pkg => {
-    return runScript('postinstall', pkg, prefix)
-  }).then(pkg => {
-    extract.stopWorkers()
-    return {
-      count: pkgCount,
-      time: Date.now() - startTime
-    }
-  })
-
-  function runScript (stage, pkg, pkgPath) {
-    if (pkg.scripts && pkg.scripts[stage]) {
-      // TODO(mikesherov): remove pkg._id when npm-lifecycle no longer relies on it
-      pkg._id = pkg.name + '@' + pkg.version
-      return config(prefix).then(config => lifecycle(pkg, stage, pkgPath, config))
-    }
-    return BB.resolve()
   }
 
-  function extractDeps (modPath, deps) {
+  extractDeps (modPath, deps) {
     return BB.map(Object.keys(deps || {}), name => {
       const child = deps[name]
       const childPath = path.join(modPath, name)
-      return extract.child(name, child, childPath)
-      .then(() => {
+      return extract.child(name, child, childPath).then(() => {
         return readJson(childPath, 'package.json')
       }).tap(pkg => {
-        return runScript('preinstall', pkg, childPath)
+        return this.runScript('preinstall', pkg, childPath)
       }).then(pkg => {
-        return extractDeps(path.join(childPath, 'node_modules'), child.dependencies)
+        return this.extractDeps(path.join(childPath, 'node_modules'), child.dependencies)
         .then(dependencies => {
           return {
             name,
@@ -100,21 +115,33 @@ function main (opts) {
           }
         })
       }).tap(full => {
-        pkgCount++
-        return runScript('install', full.package, childPath)
+        this.pkgCount++
+        return this.runScript('install', full.package, childPath)
       }).tap(full => {
-        return runScript('postinstall', full.package, childPath)
+        return this.runScript('postinstall', full.package, childPath)
       })
     }, {concurrency: 50})
   }
 
-  function readJson (jsonPath, name, ignoreMissing) {
-    return fs.readFileAsync(path.join(jsonPath, name), 'utf8')
-    .then(str => JSON.parse(str))
-    .catch({code: 'ENOENT'}, err => {
-      if (!ignoreMissing) {
-        throw err
-      }
-    })
+  runScript (stage, pkg, pkgPath) {
+    if (pkg.scripts && pkg.scripts[stage]) {
+      // TODO(mikesherov): remove pkg._id when npm-lifecycle no longer relies on it
+      pkg._id = pkg.name + '@' + pkg.version
+      return config(this.prefix).then(config => {
+        return lifecycle(pkg, stage, pkgPath, config)
+      })
+    }
+    return BB.resolve()
   }
+}
+module.exports = Installer
+
+function readJson (jsonPath, name, ignoreMissing) {
+  return readFileAsync(path.join(jsonPath, name), 'utf8')
+  .then(str => JSON.parse(str))
+  .catch({code: 'ENOENT'}, err => {
+    if (!ignoreMissing) {
+      throw err
+    }
+  })
 }

--- a/lib/get-prefix.js
+++ b/lib/get-prefix.js
@@ -1,0 +1,54 @@
+'use strict'
+
+const BB = require('bluebird')
+
+const path = require('path')
+const statAsync = BB.promisify(require('fs').stat)
+
+module.exports = getPrefix
+function getPrefix (current, root) {
+  if (!root) {
+    const original = root = path.resolve(current)
+    while (path.basename(root) === 'node_modules') {
+      root = path.dirname(root)
+    }
+    if (original !== root) {
+      return Promise.resolve(root)
+    } else {
+      return getPrefix(root, root)
+    }
+  }
+  if (isRootPath(current, process.platform)) {
+    return Promise.resolve(root)
+  } else {
+    return Promise.all([
+      fileExists(path.join(current, 'package.json')),
+      fileExists(path.join(current, 'node_modules'))
+    ]).then(args => {
+      const hasPkg = args[0]
+      const hasModules = args[1]
+      if (hasPkg || hasModules) {
+        return current
+      } else {
+        const parent = path.dirname(current)
+        return getPrefix(parent, root)
+      }
+    })
+  }
+}
+
+module.exports._fileExists = fileExists
+function fileExists (f) {
+  return statAsync(f).catch(err => {
+    if (err.code !== 'ENOENT') {
+      throw err
+    }
+  })
+}
+
+module.exports._isRootPath = isRootPath
+function isRootPath (p, platform) {
+  return platform === 'win32'
+  ? p.match(/^[a-z]+:[/\\]?$/i)
+  : p === '/'
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -5646,6 +5646,67 @@
         "string-width": "2.0.0"
       }
     },
+    "tacks": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/tacks/-/tacks-1.2.6.tgz",
+      "integrity": "sha1-BL9htjbT0KkcyFP+W1w6ulUt1F0=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.1",
+        "yargs": "3.32.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+          "dev": true
+        },
+        "os-locale": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+          "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+          "dev": true,
+          "requires": {
+            "lcid": "1.0.0"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "window-size": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
+          "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY=",
+          "dev": true
+        },
+        "yargs": {
+          "version": "3.32.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+          "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
+          "dev": true,
+          "requires": {
+            "camelcase": "2.1.1",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "os-locale": "1.4.0",
+            "string-width": "1.0.2",
+            "window-size": "0.1.4",
+            "y18n": "3.2.1"
+          }
+        }
+      }
+    },
     "tap": {
       "version": "10.7.2",
       "resolved": "https://registry.npmjs.org/tap/-/tap-10.7.2.tgz",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "require-inject": "^1.4.2",
     "standard": "^10.0.3",
     "standard-version": "^4.2.0",
+    "tacks": "^1.2.6",
     "tap": "^10.7.2",
     "weallbehave": "^1.2.0",
     "weallcontribute": "^1.0.8"

--- a/test/lib/test-dir.js
+++ b/test/lib/test-dir.js
@@ -1,0 +1,42 @@
+'use strict'
+
+const mkdirp = require('mkdirp')
+const path = require('path')
+const rimraf = require('rimraf')
+const tap = require('tap')
+
+const cacheDir = path.resolve(__dirname, '../cache')
+
+module.exports = testDir
+function testDir (filename) {
+  const base = path.basename(filename, '.js')
+  const dir = path.join(cacheDir, base)
+  tap.beforeEach(cb => {
+    reset(dir, err => {
+      if (err) { throw err }
+      cb()
+    })
+  })
+  if (!process.env.KEEPCACHE) {
+    tap.tearDown(() => {
+      process.chdir(__dirname)
+      // This is ok cause this is the last
+      // thing to run in the process
+      rimraf(dir, () => {})
+    })
+  }
+  return dir
+}
+
+module.exports.reset = reset
+function reset (testDir, cb) {
+  process.chdir(__dirname)
+  rimraf(testDir, function (err) {
+    if (err) { return cb(err) }
+    mkdirp(testDir, function (err) {
+      if (err) { return cb(err) }
+      process.chdir(testDir)
+      cb()
+    })
+  })
+}

--- a/test/specs/index.js
+++ b/test/specs/index.js
@@ -9,7 +9,7 @@ const pkgName = 'hark-a-package'
 const pkgVersion = '1.0.0'
 const writeEnvScript = 'node -e \'const fs = require("fs"); fs.writeFileSync(process.cwd() + "/" + process.env.npm_lifecycle_event, process.env.npm_lifecycle_event);\''
 
-const main = requireInject('../../index.js', {
+const Installer = requireInject('../../index.js', {
   '../../lib/extract': {
     startWorkers () {},
     stopWorkers () {},
@@ -24,7 +24,7 @@ test('throws error when no package.json is found', t => {
     'index.js': 'var a = 1;'
   })
 
-  main({ prefix: prefix }).catch(err => {
+  new Installer({prefix}).run().catch(err => {
     t.equal(err.code, 'ENOENT')
 
     fixtureHelper.teardown()
@@ -40,7 +40,7 @@ test('throws error when no package-lock nor shrinkwrap is found', t => {
     }
   })
 
-  main({ prefix: prefix }).catch(err => {
+  new Installer({prefix}).run().catch(err => {
     t.equal(err.message, 'cipm can only install packages with an existing package-lock.json or npm-shrinkwrap.json with lockfileVersion >= 1. Run an install with npm@5 or later to generate it, then try again.')
 
     fixtureHelper.teardown()
@@ -57,7 +57,7 @@ test('throws error when old shrinkwrap is found', t => {
     'npm-shrinkwrap.json': {}
   })
 
-  main({ prefix: prefix }).catch(err => {
+  new Installer({prefix}).run().catch(err => {
     t.equal(err.message, 'cipm can only install packages with an existing package-lock.json or npm-shrinkwrap.json with lockfileVersion >= 1. Run an install with npm@5 or later to generate it, then try again.')
 
     fixtureHelper.teardown()
@@ -77,8 +77,8 @@ test('handles empty dependency list', t => {
     }
   })
 
-  main({ prefix: prefix }).then(details => {
-    t.equal(details.count, 0)
+  new Installer({prefix}).run().then(details => {
+    t.equal(details.pkgCount, 0)
 
     fixtureHelper.teardown()
     t.end()
@@ -111,8 +111,8 @@ test('handles dependency list with only shallow subdeps', t => {
     }
   })
 
-  main({ prefix: prefix }).then(details => {
-    t.equal(details.count, 1)
+  new Installer({prefix}).run().then(details => {
+    t.equal(details.pkgCount, 1)
     t.ok(fixtureHelper.equals(prefix + '/node_modules/a', 'index.js', aContents))
 
     fixtureHelper.teardown()
@@ -158,8 +158,8 @@ test('handles dependency list with only deep subdeps', t => {
     }
   })
 
-  main({ prefix: prefix }).then(details => {
-    t.equal(details.count, 2)
+  new Installer({prefix}).run().then(details => {
+    t.equal(details.pkgCount, 2)
     t.ok(fixtureHelper.equals(prefix + '/node_modules/a', 'index.js', aContents))
     t.ok(fixtureHelper.equals(prefix + '/node_modules/a/node_modules/b', 'index.js', bContents))
 
@@ -204,8 +204,8 @@ test('runs lifecycle hooks of packages with env variables', t => {
     }
   })
 
-  main({ prefix: prefix }).then(details => {
-    t.equal(details.count, 1)
+  new Installer({prefix}).run().then(details => {
+    t.equal(details.pkgCount, 1)
     t.ok(fixtureHelper.equals(prefix, 'preinstall', 'preinstall'))
     t.ok(fixtureHelper.equals(prefix, 'install', 'install'))
     t.ok(fixtureHelper.equals(prefix, 'postinstall', 'postinstall'))

--- a/test/specs/lib/get-prefix.js
+++ b/test/specs/lib/get-prefix.js
@@ -1,0 +1,122 @@
+'use strict'
+
+const os = require('os')
+const path = require('path')
+const requireInject = require('require-inject')
+const Tacks = require('tacks')
+const test = require('tap').test
+const testDir = require('../../lib/test-dir.js')(__filename)
+
+const Dir = Tacks.Dir
+const File = Tacks.File
+
+const getPrefix = require('../../../lib/get-prefix.js')
+
+test('navigates out of `node_modules` without fs nav', t => {
+  return getPrefix(
+    path.join(testDir, 'node_modules', 'node_modules')
+  ).then(val => {
+    t.equal(val, testDir, 'navigates out of node_modules')
+  })
+})
+
+test('detects if currently in an npm package using package.json', t => {
+  const fixture = new Tacks(Dir({
+    'package.json': File({name: 'foo', version: '1.2.3'})
+  }))
+  fixture.create(testDir)
+  return getPrefix(testDir).then(prefix => {
+    t.equal(prefix, testDir, 'current dir worked out')
+  })
+})
+
+test('detects if currently in an npm package using node_modules', t => {
+  const fixture = new Tacks(Dir({
+    'node_modules': Dir({})
+  }))
+  fixture.create(testDir)
+  return getPrefix(testDir).then(prefix => {
+    t.equal(prefix, testDir, 'current dir worked out')
+  })
+})
+
+test('returns the same path if no package was found in parent dirs', t => {
+  // Hopefully folks' tmpdir isn't inside an npm package ;)
+  const tmp = os.tmpdir()
+  return getPrefix(tmp).then(prefix => {
+    t.equal(prefix, tmp, 'returned the same path')
+  })
+})
+
+test('navigates up the filesystem until it finds a package', t => {
+  const fixture = new Tacks(Dir({
+    'node_modules': Dir({}),
+    'a': Dir({'b': Dir({'c': Dir({'d': Dir({})})})})
+  }))
+  fixture.create(testDir)
+  return getPrefix(path.join(testDir, 'a', 'b', 'c')).then(prefix => {
+    t.equal(prefix, testDir, 'navigated all the way up')
+  })
+})
+
+test('doesn\'t go too far while navigating up', t => {
+  const fixture = new Tacks(Dir({
+    'node_modules': Dir({}),
+    'a': Dir({'node_modules': Dir({}), 'b': Dir({'c': Dir({'d': Dir({})})})})
+  }))
+  fixture.create(testDir)
+  return getPrefix(path.join(testDir, 'a', 'b', 'c')).then(prefix => {
+    t.equal(prefix, path.join(testDir, 'a'), 'stopped before root')
+  })
+})
+
+test('returns root if we get there', t => {
+  let root = '/'
+  if (process.platform === 'win32') {
+    const currentDrive = process.cwd().match(/^([a-z]+):/i)[1]
+    root = `${currentDrive}:\\`
+  }
+  return getPrefix(root).then(prefix => {
+    t.equal(prefix, root, 'used the same root')
+  })
+})
+
+test('fileExists unit', t => {
+  const fileExists = requireInject('../../../lib/get-prefix.js', {
+    fs: {
+      stat (todo, cb) {
+        if (todo === 'exists') {
+          cb(null, {name: 'yay'})
+        } else if (todo === 'enoent') {
+          const err = new Error('not found')
+          err.code = 'ENOENT'
+          cb(err)
+        } else {
+          cb(new Error('idk'))
+        }
+      }
+    }
+  })._fileExists
+  return Promise.all([
+    fileExists('exists'),
+    fileExists('enoent'),
+    fileExists('kaboom').then(() => {
+      throw new Error('nope')
+    }, err => err)
+  ]).then(results => {
+    t.deepEqual(results[0], {name: 'yay'}, 'existing stat returned')
+    t.notOk(results[1], 'missing file succeeds with falsy')
+    t.match(results[2].message, /^idk$/, 'other errors thrown')
+  })
+})
+
+test('isRootPath unit', t => {
+  const isRoot = getPrefix._isRootPath
+  t.ok(isRoot('C:\\', 'win32'), 'detected root on windows')
+  t.notOk(isRoot('C:\\foo', 'win32'), 'detected non-root on windows')
+  t.ok(isRoot('/', 'darwin'), 'detected root on darwin')
+  t.notOk(isRoot('/foo', 'darwin'), 'detected non-root on darwin')
+  t.ok(isRoot('/', 'linux'), 'detected root on linux')
+  t.notOk(isRoot('/foo', 'linux'), 'detected non-root on linux')
+  t.done()
+})


### PR DESCRIPTION
This rewrites the toplevel installer such that it uses object+method style instead of a bunch of toplevel functions. This is mainly useful so we can keep installer state over time: for example, I plan on using this to keep a "logical tree" around that I can use so scripts run in their _logical_ dependency order.

As a bonus, this also pulls in `get-prefix` so we calculate the installer prefix using the same logic as npm.