### PR TITLE
fix(test): add test for package/lock mismatch

### DIFF
--- a/test/specs/index.js
+++ b/test/specs/index.js
@@ -48,6 +48,28 @@ test('throws error when no package-lock nor shrinkwrap is found', t => {
   })
 })
 
+test('throws error when package.json and package-lock.json do not match', t => {
+  const prefix = fixtureHelper.write(pkgName, {
+    'package.json': {
+      name: pkgName,
+      version: pkgVersion,
+      dependencies: { a: '1' }, // should generate error
+      optionalDependencies: { b: '2' } // should generate warning
+    },
+    'package-lock.json': {
+      version: pkgVersion + '-0',
+      dependencies: {},
+      lockfileVersion: 1
+    }
+  })
+
+  new Installer({prefix}).run().catch(err => {
+    t.match(err.message, 'cipm can only install packages when your package.json and package-lock.json or npm-shrinkwrap.json are in sync')
+    fixtureHelper.teardown()
+    t.end()
+  })
+})
+
 test('throws error when old shrinkwrap is found', t => {
   const prefix = fixtureHelper.write(pkgName, {
     'package.json': {


### PR DESCRIPTION
File            |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
----------------|----------|----------|----------|----------|----------------|
All files       |    99.12 |    97.37 |     97.5 |      100 |                |
 cipm           |    98.41 |    94.44 |    96.43 |      100 |                |
  index.js      |    98.41 |    94.44 |    96.43 |      100 |             35 |
 cipm/lib       |      100 |      100 |      100 |      100 |                |
  config.js     |      100 |      100 |      100 |      100 |                |
  get-prefix.js |      100 |      100 |      100 |      100 |                |

(TIL: the coverage report from nyc/instanbul is valid markdown if you strip the first and last line)