### PR TITLE
chore: update CI to node 4,6,8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 # cipm currently relies on npm >5.4.0 to retrieve config
 before_install:
-  - npm i -g npm@5.4.0
+  - npm i -g npm@^5.4.0
 language: node_js
 sudo: false
 node_js:
-  - "7"
+  - "8"
   - "6"
   - "4"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 environment:
   matrix:
-    - nodejs_version: "7"
+    - nodejs_version: "8"
     - nodejs_version: "6"
     - nodejs_version: "4"
 
@@ -10,7 +10,7 @@ platform:
 install:
   - ps: Install-Product node $env:nodejs_version $env:platform
   - npm config set spin false
-  - npm i -g npm@latest
+  - npm i -g npm@^5.4.0
   - npm install
 
 test_script:


### PR DESCRIPTION
Also make npm dep consistent since 5.4.0 is the minimum version required
for the functionality that is being used.

@zkat this shouldn't interfere with your plans to switch to tack (in case that wasn't obvious and you haven't looked at the diff yet).