### PR TITLE
ignore failed optional deps (not ready)

### DIFF
--- a/index.js
+++ b/index.js
@@ -116,9 +116,13 @@ class Installer {
         })
       }).tap(full => {
         this.pkgCount++
-        return this.runScript('install', full.package, childPath)
-      }).tap(full => {
-        return this.runScript('postinstall', full.package, childPath)
+        return this.runScript('install', full.package, childPath).then(() => {
+          return this.runScript('postinstall', full.package, childPath)
+        }).catch(err => {
+          if (!child.optional) {
+            throw err
+          }
+        })
       })
     }, {concurrency: 50})
   }


### PR DESCRIPTION
okay, so this will ignore failed optional deps by just eating the errors.  however, the optional packages are counted towards the total package count, and the object is passed on thru the promise chain as if nothing bad occurred, which might not be what we want.

IMO ignoring the failures is probably sufficient (instead of trying to prune the tree), because if we're running on CI, who cares, right?

what'd be your preferred strategy to test this behavior?

I had to nest the promises or the `tap()` calls wouldn't work.