### PR TITLE
fix(lockfile): npm-shrinkwrap takes precedence over package-lock

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ class Installer {
         readJson(prefix, 'package-lock.json', true),
         readJson(prefix, 'npm-shrinkwrap.json', true),
         (pkg, lock, shrink) => {
-          pkg._shrinkwrap = lock || shrink
+          pkg._shrinkwrap = shrink || lock
           this.pkg = pkg
         }
       )


### PR DESCRIPTION
This better matches the behavior of npm5 itself.

<!--
⚠️🚨 BEFORE FILING A PR: 🚨⚠️

👉🏼 CONTRIBUTING.md 👈🏼 (the "contribution guidelines" up there ☝🏼)

I PROMISE IT'S A VERY VERY SHORT READ.🙇🏼
-->
