### PR TITLE
feat(offline-packages): add 'offline-packages' config option

### DIFF
--- a/lib/extract.js
+++ b/lib/extract.js
@@ -1,8 +1,11 @@
 'use strict'
 
+const fs = require('fs')
+const path = require('path')
 const BB = require('bluebird')
 
 const npa = require('npm-package-arg')
+const pacote = require('pacote')
 const pacoteOpts = require('./pacote-opts.js')
 const workerFarm = require('worker-farm')
 
@@ -24,10 +27,28 @@ module.exports = {
   child (name, child, childPath, opts) {
     if (child.bundled) return BB.resolve()
 
+    let shouldFetch = false
+    if (opts.config['offline-packages']) {
+      const offlinePath = path.join(process.cwd(), opts.config['offline-packages'])
+      const packagePath = path.join(offlinePath, path.basename(child.resolved))
+      const packageExists = !fs.existsSync(packagePath)
+      if (!fs.existsSync(packagePath)) {
+        if (opts.config.offline) throw new Error(`Could not find ${packagePath}`)
+          shouldFetch = packagePath
+      } else {
+        child.resolved = packagePath
+      }
+    }
+
     const spec = npa.resolve(name, child.resolved || child.version)
     const childOpts = pacoteOpts(opts, {
       integrity: child.integrity
     })
+
+    if (shouldFetch) {
+      pacote.tarball.toFile(spec, shouldFetch)
+    }
+
     const args = [spec, childPath, childOpts]
     return BB.fromNode((cb) => {
       let launcher = extractionWorker

--- a/lib/pacote-opts.js
+++ b/lib/pacote-opts.js
@@ -24,6 +24,7 @@ function pacoteOpts (npmOpts, moreOpts) {
     maxSockets: +(conf['maxsockets'] || 15),
     npmSession: npmSession,
     offline: conf['offline'],
+    offlinePackages: conf['offline-packages'],
     projectScope: getProjectScope((npmOpts.rootPkg || moreOpts.rootPkg).name),
     proxy: conf['https-proxy'] || conf['proxy'],
     refer: 'cipm',


### PR DESCRIPTION
Adds the `offline-packages` config option. It should be set to a _path_ where package tarballs will be stored, and used as sources in offline mode.

#### Motivation

I want to able to keep all project dependencies colocated with the source code, and be able to 're-hydrate' the whole project fully offline and without any external dependencies whatsoever (like an external package cache). This approach is similar to [yarn's offline mirror](yarnpkg.com/blog/2016/11/24/offline-mirror/), which works, but still has some drawbacks:

- can generate churn on `yarn.lock` and the mirror folder depending on how it's used
- there is still an intermediate global cache involved
- requires explicit `--offline` and `--check-files` flags to achieve a clean install from cache

Pointing the npm cache to a local folder is a possibility, but committing the cache contents makes for very polluted diffs, not much better than committing node_modules itself. Storing `.tgz` is ideal as the contents don't show up in diffs, and it also significantly reduces total archive size.

#### Other options

I also tried to make this work with vanilla npm, but ended up having to use `npm pack` which is extremely slow, and would end up overwriting either `package.json` or `package-lock.json` with `file:...` resolutions. It also can't seamlessly switch between online and offline mode, I could not achieve a sane setup.

[pnpm](https://github.com/pnpm/pnpm) is very fast, but stores both a `packed.tgz` _and_ the extracted source code in it's cache folder, using more space than necessary and clogging up diffs.

The alternatives are also much more complex than cipm and more prone to breaking with future npm updates - I really like how *cipm* reaches out directly to npm's guts and manages to implement consistent behaviour with very little code.

----

This PR is more of a request for comments and feedback, not expecting it to be merged as-is. It appears to work for the largest repo I have, node_modules structure matches npm install, but needs more extensive testing (and tests!). Performance seems to be on par with `yarn --offline` which is great.

Thank you for this project!
