### PR TITLE
fix(package): add pacote to bundleDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "npm-logical-tree",
     "npm-package-arg",
     "npmlog",
+    "pacote",
     "read-package-json",
     "rimraf",
     "worker-farm",


### PR DESCRIPTION
89e0705 bundled all prod dependencies _except_ pacote, which forces an `npm install` every time it is provisioned onto a build host. Contrast with npm itself, whose tarball can be directly downloaded from the public registry and unpacked into a functional program in one step.

This change increases the packed tarball size from ~2.1MB to ~2.9MB.

I'm not sure how to add a test for this, but here's the shell commands I used to validate the change:
```bash
$ git checkout latest
$ npm it
$ npm pack
$ tar tf cipm-0.8.0.tgz | grep '/pacote/' -c
0
$ mv cipm-0.8.0.tgz{,.old}
$ git checkout bundle-pacote
$ npm pack
$ tar tf cipm-0.8.0.tgz | grep '/pacote/' -c
66
$ ls -loh cipm*
-rw-r--r--  1 daniels   2.9M Dec 18 10:40 cipm-0.8.0.tgz
-rw-r--r--  1 daniels   2.1M Dec 18 10:32 cipm-0.8.0.tgz.old
```
