### PR TITLE
feat(extract): link directory deps and install missing bundle deps

### DIFF
--- a/lib/extract.js
+++ b/lib/extract.js
@@ -21,8 +21,6 @@ module.exports = {
   },
 
   child (name, child, childPath, config, opts) {
-    if (child.bundled) return BB.resolve()
-
     const spec = npa.resolve(name, child.version)
     const childOpts = config.toPacote(Object.assign({
       integrity: child.integrity,


### PR DESCRIPTION
This replicates npm's `directory` dependency behavior. It also fixes the logic around bundleDeps such that if a package is missing a certain bundledDep, it will make sure to install it from its specifier -- this is usually, ideally, not necessary, and npm itself spit out loud warnings if a bad tarball like this shows up, but it turns out it also marks nested dependencies in "external" `directory` deps as `bundled` to achieve the current behavior of installing only if the deps for that linked dep is missing.