### PR TITLE
fix(impl) don't reference prefix before computing it

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,14 +48,13 @@ class Installer {
   }
 
   run () {
-    const prefix = this.prefix
     return this.timedStage('prepare')
       .then(() => this.timedStage('extractTree', this.tree))
       .then(() => this.timedStage('updateJson', this.tree))
       .then(pkgJsons => this.timedStage('buildTree', this.tree, pkgJsons))
       .then(() => this.timedStage('garbageCollect', this.tree))
-      .then(() => this.timedStage('runScript', 'prepublish', this.pkg, prefix))
-      .then(() => this.timedStage('runScript', 'prepare', this.pkg, prefix))
+      .then(() => this.timedStage('runScript', 'prepublish', this.pkg, this.prefix))
+      .then(() => this.timedStage('runScript', 'prepare', this.pkg, this.prefix))
       .then(() => this.timedStage('teardown'))
       .then(() => {
         this.runTime = Date.now() - this.startTime


### PR DESCRIPTION
`this.prefix` is computed and set in [prepare](https://github.com/zkat/cipm/blob/8ddc94d25849d4fcf1a792514dbf4209da5e2144/index.js#L90), which is called _after_ it's currently [referenced in run](https://github.com/zkat/cipm/blob/8ddc94d25849d4fcf1a792514dbf4209da5e2144/index.js#L50). This ensures that the resolved value is passed to `prepare` and `prepublish` as the wd, rather than `undefined`.

This fixes two bugs:
1. `npm ci` would fail if the root package had a "prepare" or "prepublish" script that used a local npm binary (e.g. `babel src -d lib`), because npm-lifecycle would [fall back on using <pkg>/node_modules/](https://github.com/npm/lifecycle/blob/ca5f92074f2861be437c0102a74826a48d7c773f/index.js#L51) so node_modules/node_modules/.bin/ would get added to the path instead of node_modules/.bin/.
2. `npm ci`, run as root (e.g. in a Docker container) would fail to run a root package's "prepare" or "prepublish" scripts at all, because the incorrect wd would cause [this check](https://github.com/npm/lifecycle/blob/ca5f92074f2861be437c0102a74826a48d7c773f/index.js#L83) to fail, called [here](https://github.com/npm/lifecycle/blob/ca5f92074f2861be437c0102a74826a48d7c773f/index.js#L54), such that when `unsafe-perm=false`, the script would exit early.

The second bug also occurs when running `npm install`; I haven't had a chance to look into why.