### PR TITLE
Set non-zero exit code on error

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -29,8 +29,8 @@ function cliMain () {
         details.runTime / 1000
       }s`),
       err => {
-        console.error(`cipm failed:\n${err.message}\n${err.stack}`);
-        process.exitCode = 1;
+        console.error(`cipm failed:\n${err.message}\n${err.stack}`)
+        process.exitCode = 1
       }
     )
 }

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -28,7 +28,10 @@ function cliMain () {
       details => console.error(`added ${details.pkgCount} packages in ${
         details.runTime / 1000
       }s`),
-      err => console.error(`cipm failed:\n${err.message}\n${err.stack}`)
+      err => {
+        console.error(`cipm failed:\n${err.message}\n${err.stack}`);
+        process.exitCode = 1;
+      }
     )
 }
 


### PR DESCRIPTION
I noticed that when `cipm` fails (due to missing npm-shrinkwrap.json, oops), it still exits `0`, so the CI process continues on as usual, and errors later on. This sets `process.exitCode` to 1 when the installer promise is rejected.

I don't write a lot of JS so I'm not sure if this is the right way to do this (rather than using `process.exit(1)`?). I also couldn't find any tests for the code in `bin/cli.js` - if you'd like me to add tests could you point me in the right direction?