### PR TITLE
fix(prefix): Resolve to promise when passing --prefix to npm ci

### DIFF
--- a/index.js
+++ b/index.js
@@ -91,7 +91,7 @@ class Installer {
         // There's some Special™ logic around the `--prefix` config when it
         // comes from a config file or env vs when it comes from the CLI
         : process.argv.some(arg => arg.match(/^\s*--prefix\s*/i))
-          ? this.config.get('prefix')
+          ? BB.resolve(this.config.get('prefix'))
           : getPrefix(process.cwd())
     )
       .then(prefix => {


### PR DESCRIPTION
With npm v5.7.1, I am transitioning some `npm install`s in our CI to `npm ci`. For some projects, we have a custom location to install dependencies. Therefore we pass `--prefix` to `npm install`. 

However, while doing that with `npm ci`, there was an error ([Stacktrace can be found here](https://gist.github.com/umarov/887a043ec5562f623680f4fc441f7fb7)). 

I followed the code and saw that in one of the branches of the prefix resolver, promise isn't being returned. That's why it was blowing up. I tested this locally and `npm ci` successfully completed.
