### PR TITLE
delete contents of node_modules but keep the dir itself

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,6 @@ const path = require('path')
 const readPkgJson = BB.promisify(require('read-package-json'))
 const rimraf = BB.promisify(require('rimraf'))
 
-const readdirAsync = BB.promisify(fs.readdir)
 const readFileAsync = BB.promisify(fs.readFile)
 const statAsync = BB.promisify(fs.stat)
 const symlinkAsync = BB.promisify(fs.symlink)
@@ -121,9 +120,7 @@ class Installer {
         )
         return BB.join(
           this.checkLock(),
-          stat && readdirAsync(path.join(this.prefix, 'node_modules')).then(children =>
-            BB.join(children.map(child => rimraf(path.join(this.prefix, 'node_modules', child))))
-          )
+          stat && rimraf(path.join(this.prefix, 'node_modules/*'))
         )
       }).then(() => {
       // This needs to happen -after- we've done checkLock()

--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ const path = require('path')
 const readPkgJson = BB.promisify(require('read-package-json'))
 const rimraf = BB.promisify(require('rimraf'))
 
+const readdirAsync = BB.promisify(fs.readdir)
 const readFileAsync = BB.promisify(fs.readFile)
 const statAsync = BB.promisify(fs.stat)
 const symlinkAsync = BB.promisify(fs.symlink)
@@ -120,7 +121,9 @@ class Installer {
         )
         return BB.join(
           this.checkLock(),
-          stat && rimraf(path.join(this.prefix, 'node_modules'))
+          stat && readdirAsync(path.join(this.prefix, 'node_modules')).then(children =>
+            BB.join(children.map(child => rimraf(path.join(this.prefix, 'node_modules', child))))
+          )
         )
       }).then(() => {
       // This needs to happen -after- we've done checkLock()


### PR DESCRIPTION
Keep `node_modules` directory but delete its contents.

In some CI setups `node_modules` is a special directory, e.g. a mounted folder or a symbolic link. For these setups simply deleting `node_modules` won't work, or worse will work but break the CI setup. Deleting `node_modules` is a also a non-trivial deviation from the expected behavior of `npm install` which means the existing CI setups that are explained above are blocked from migrating to `npm ci`.

`npm ci` should minimize violent changes and concentrate on the fact we want to reset the installed dependencies and proceed with the regular flow. Keep `node_modules` untouched, doesn't matter how it was created.