### PR TITLE
fix(child): only override dirPacker if opts.dirPacker is defined

### DIFF
--- a/lib/extract.js
+++ b/lib/extract.js
@@ -22,12 +22,14 @@ module.exports = {
 
   child (name, child, childPath, config, opts) {
     const spec = npa.resolve(name, child.version)
+    const additionalToPacoteOpts = {}
+    if (typeof opts.dirPacker !== 'undefined') {
+      additionalToPacoteOpts.dirPacker = opts.dirPacker
+    }
     const childOpts = config.toPacote(Object.assign({
       integrity: child.integrity,
       resolved: child.resolved
-    }, {
-      dirPacker: opts.dirPacker
-    }))
+    }, additionalToPacoteOpts))
     const args = [spec, childPath, childOpts]
     return BB.fromNode((cb) => {
       let launcher = extractionWorker

--- a/test/specs/lib/extract.js
+++ b/test/specs/lib/extract.js
@@ -1,0 +1,30 @@
+'use strict'
+
+const test = require('tap').test
+const requireInject = require('require-inject')
+
+const extract = requireInject('../../../lib/extract.js', {
+  '../../../lib/worker.js': (msg, cb) => { cb(null, msg) },
+  'npm-package-arg': {
+    resolve: () => ({ registry: false, type: 'not-remote' })
+  }
+})
+
+test('extract.child() only overwrites dirPacker when opts.dirPacker is defined', t => {
+  const name = 'name'
+  const child = { version: '0.0.0', integrity: 'integrity', resolved: 'resolved' }
+  const childPath = './path'
+  const config = {
+    toPacote (moreOpts) {
+      return moreOpts
+    }
+  }
+
+  const opts = { log: { level: 'level' } }
+  const a = extract.child(name, child, childPath, config, opts)
+
+  a.then(b => {
+    t.ok(!('dirPacker' in b[2]), 'An undefined dirPacker overrode the pacote childOpts')
+    t.end()
+  })
+})


### PR DESCRIPTION
This pull request fixes the issue described in the forum post: [Using npm ci does not run prepare script for git modules](https://npm.community/t/using-npm-ci-does-not-run-prepare-script-for-git-modules/632).

I didn't see any good example tests for `lib/extract.js`, so I didn't add any. If you have pointers on how you'd want a test for this change structured, I can add one.