### PR TITLE
fix(checkDepEnvs): always install root pkg

### DIFF
--- a/index.js
+++ b/index.js
@@ -252,6 +252,7 @@ class Installer {
   }
 
   checkDepEnv (dep) {
+    if (dep.isRoot) { return true }
     const includeDev = (
       // Covers --dev and --development (from npm config itself)
       this.opts.dev ||


### PR DESCRIPTION
Always 'install' the root package, instead of ignoring it when `--only=dev` is passed.

See https://npm.community/t/3068

<!--
⚠️🚨 BEFORE FILING A PR: 🚨⚠️

👉🏼 CONTRIBUTING.md 👈🏼 (the "contribution guidelines" up there ☝🏼)

I PROMISE IT'S A VERY VERY SHORT READ.🙇🏼
-->
