### PR TITLE
feat(libcipm): keep node_modules until lock checked

### DIFF
--- a/index.js
+++ b/index.js
@@ -147,6 +147,7 @@ class Installer {
           }
         )
       })
+      .then(() => this.checkLock())
       .then(() => statAsync(
         path.join(this.prefix, 'node_modules')
       ).catch(err => { if (err.code !== 'ENOENT') { throw err } }))
@@ -154,10 +155,7 @@ class Installer {
         stat && this.log.warn(
           'prepare', 'removing existing node_modules/ before installation'
         )
-        return BB.join(
-          this.checkLock(),
-          stat && rimraf(path.join(this.prefix, 'node_modules'))
-        )
+        return stat && rimraf(path.join(this.prefix, 'node_modules'))
       }).then(() => {
       // This needs to happen -after- we've done checkLock()
         this.tree = buildLogicalTree(this.pkg, this.pkg._shrinkwrap)


### PR DESCRIPTION
Keep `node_modules/` until `package-lock.json` is verified.

See https://npm.community/t/4057

<!--
⚠️🚨 BEFORE FILING A PR: 🚨⚠️

👉🏼 CONTRIBUTING.md 👈🏼 (the "contribution guidelines" up there ☝🏼)

I PROMISE IT'S A VERY VERY SHORT READ.🙇🏼
-->
